### PR TITLE
Skiptables Argparse Option

### DIFF
--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -16,6 +16,8 @@ def main():
     parser.add_argument('--version', action='store_true', help="print the version number and exit")
     parser.add_argument('--schema', help='load tables from an alternate schema')
     parser.add_argument('--tables', help='tables to process (comma-separated, default: all)')
+    parser.add_argument('--skiptables', help='tables to skip ('
+                                             'comma-separated, default: none')
     parser.add_argument('--noviews', action='store_true', help="ignore views")
     parser.add_argument('--noindexes', action='store_true', help='ignore indexes')
     parser.add_argument('--noconstraints', action='store_true', help='ignore constraints')

--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -17,7 +17,7 @@ def main():
     parser.add_argument('--schema', help='load tables from an alternate schema')
     parser.add_argument('--tables', help='tables to process (comma-separated, default: all)')
     parser.add_argument('--skiptables', help='tables to skip ('
-                                             'comma-separated, default: none')
+                                             'comma-separated, default: none)')
     parser.add_argument('--noviews', action='store_true', help="ignore views")
     parser.add_argument('--noindexes', action='store_true', help='ignore indexes')
     parser.add_argument('--noconstraints', action='store_true', help='ignore constraints')
@@ -43,6 +43,9 @@ def main():
     else:
         tables = None
     metadata.reflect(engine, args.schema, not args.noviews, tables)
+    if args.skiptables:
+        tables = set(metadata.tables.keys())-set(args.skiptables.split(','))
+        metadata.reflect(engine, args.schema, not args.noviews, tables)
     outfile = codecs.open(args.outfile, 'w', encoding='utf-8') if args.outfile else sys.stdout
     generator = CodeGenerator(metadata, args.noindexes, args.noconstraints, args.nojoined, args.noinflect,
                               args.noclasses)

--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -38,7 +38,10 @@ def main():
 
     engine = create_engine(args.url)
     metadata = MetaData(engine)
-    tables = args.tables.split(',') if args.tables else None
+    if args.tables:
+        tables = args.tables.split(',')
+    else:
+        tables = None
     metadata.reflect(engine, args.schema, not args.noviews, tables)
     outfile = codecs.open(args.outfile, 'w', encoding='utf-8') if args.outfile else sys.stdout
     generator = CodeGenerator(metadata, args.noindexes, args.noconstraints, args.nojoined, args.noinflect,

--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -1,4 +1,5 @@
-from __future__ import unicode_literals, division, print_function, absolute_import
+from __future__ import unicode_literals, division, print_function, \
+    absolute_import
 import argparse
 import codecs
 import sys
@@ -10,22 +11,44 @@ import pkg_resources
 from sqlacodegen.codegen import CodeGenerator
 
 
-def main():
-    parser = argparse.ArgumentParser(description='Generates SQLAlchemy model code from an existing database.')
-    parser.add_argument('url', nargs='?', help='SQLAlchemy url to the database')
-    parser.add_argument('--version', action='store_true', help="print the version number and exit")
-    parser.add_argument('--schema', help='load tables from an alternate schema')
-    parser.add_argument('--tables', help='tables to process (comma-separated, default: all)')
+def parser_factory():
+    '''
+    A factory method to generate a parser with standard args
+    :return: ArgumentParser
+    '''
+    parser = argparse.ArgumentParser(
+        description='Generates SQLAlchemy model '
+                    'code from an existing database.')
+    parser.add_argument('url', nargs='?',
+                        help='SQLAlchemy url to the database')
+    parser.add_argument('--version', action='store_true',
+                        help="print the version number and exit")
+    parser.add_argument('--schema',
+                        help='load tables from an alternate schema')
+    parser.add_argument('--tables',
+                        help='tables to process '
+                             '(comma-separated, default: all)')
     parser.add_argument('--skiptables', help='tables to skip ('
                                              'comma-separated, default: none)')
     parser.add_argument('--noviews', action='store_true', help="ignore views")
-    parser.add_argument('--noindexes', action='store_true', help='ignore indexes')
-    parser.add_argument('--noconstraints', action='store_true', help='ignore constraints')
-    parser.add_argument('--nojoined', action='store_true', help="don't autodetect joined table inheritance")
-    parser.add_argument('--noinflect', action='store_true', help="don't try to convert tables names to singular form")
-    parser.add_argument('--noclasses', action='store_true', help="don't generate classes, only tables")
-    parser.add_argument('--outfile', help='file to write output to (default: stdout)')
-    args = parser.parse_args()
+    parser.add_argument('--noindexes', action='store_true',
+                        help='ignore indexes')
+    parser.add_argument('--noconstraints', action='store_true',
+                        help='ignore constraints')
+    parser.add_argument('--nojoined', action='store_true',
+                        help="don't autodetect joined table inheritance")
+    parser.add_argument('--noinflect', action='store_true',
+                        help="don't try to convert "
+                             "tables names to singular form")
+    parser.add_argument('--noclasses', action='store_true',
+                        help="don't generate classes, only tables")
+    parser.add_argument('--outfile',
+                        help='file to write output to (default: stdout)')
+    return parser
+
+
+def main():
+    args = parser_factory().parse_args()
 
     if args.version:
         version = pkg_resources.get_distribution('sqlacodegen').parsed_version
@@ -44,9 +67,12 @@ def main():
         tables = None
     metadata.reflect(engine, args.schema, not args.noviews, tables)
     if args.skiptables:
-        tables = set(metadata.tables.keys())-set(args.skiptables.split(','))
+        tables = list(set(metadata.tables.keys()) - set(args.skiptables.split(
+            ',')))
         metadata.reflect(engine, args.schema, not args.noviews, tables)
-    outfile = codecs.open(args.outfile, 'w', encoding='utf-8') if args.outfile else sys.stdout
-    generator = CodeGenerator(metadata, args.noindexes, args.noconstraints, args.nojoined, args.noinflect,
+    outfile = codecs.open(args.outfile, 'w',
+                          encoding='utf-8') if args.outfile else sys.stdout
+    generator = CodeGenerator(metadata, args.noindexes, args.noconstraints,
+                              args.nojoined, args.noinflect,
                               args.noclasses)
     generator.render(outfile)


### PR DESCRIPTION
Ref: Issue #37 

## Implementation Details
Overall, this keeps much of the same behavior as before, with an added option. 

- We reflect and grab user-listed tables or all, 
- then parse skip tables. 
- If skip-tables, we set diff with tables found from prior reflect, 
- and re-reflect.

This seems like a simple step, but I am aware that they're are probably better ways to get the tables all in one fell-swoop, grabbing all tables and diffing. Suggestions for diff implementation? Any API tricks on SQLAlchemy?
