### PR TITLE
Add note to README about tables w/ no primary key

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,8 @@ transforming the next letter to upper case. For example, ``sales_invoices``
 becomes ``SalesInvoice``.
 
 Classes will not be created for tables lacking a primary key; these tables
-will appear instead as instances of `Table` in the generated code.
+will appear instead as instances of ``sqlalchemy.Table`` in the generated
+code.
 
 
 Relationship detection logic

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,9 @@ form using the "inflect" library. Then, every underscore is removed while
 transforming the next letter to upper case. For example, ``sales_invoices``
 becomes ``SalesInvoice``.
 
+Classes will not be created for tables lacking a primary key; these tables
+will appear instead as instances of `Table` in the generated code.
+
 
 Relationship detection logic
 ----------------------------


### PR DESCRIPTION
Add a note to the README stating that tables with no primary key will be generated as instances of `Table` rather than classes.

Ref: #48