### PR TITLE
Import vendor-specific types when generic types cannot be used.

### DIFF
--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -5,6 +5,7 @@ import inspect
 import re
 import sys
 from collections import defaultdict
+from importlib import import_module
 from inspect import ArgSpec
 from keyword import iskeyword
 
@@ -58,7 +59,19 @@ def _get_constraint_sort_key(constraint):
 class ImportCollector(OrderedDict):
     def add_import(self, obj):
         type_ = type(obj) if not isinstance(obj, type) else obj
-        pkgname = 'sqlalchemy' if type_.__name__ in sqlalchemy.__all__ else type_.__module__
+        pkgname = type_.__module__
+
+        # The column types have already been adapted towards generic types if possible, so if this
+        # is still a vendor specific type (e.g., MySQL INTEGER) be sure to use that rather than the
+        # generic sqlalchemy type as it might have different constructor parameters.
+        if pkgname.startswith('sqlalchemy.dialects.'):
+            dialect_pkgname = '.'.join(pkgname.split('.')[0:3])
+            dialect_pkg = import_module(dialect_pkgname)
+
+            if type_.__name__ in dialect_pkg.__all__:
+                pkgname = dialect_pkgname
+        else:
+            pkgname = 'sqlalchemy' if type_.__name__ in sqlalchemy.__all__ else type_.__module__
         self.add_literal_import(pkgname, type_.__name__)
 
     def add_literal_import(self, pkgname, name):
@@ -89,16 +102,18 @@ class Model(object):
                 for key, value in kw.items():
                     setattr(new_coltype, key, value)
 
+                if isinstance(coltype, ARRAY):
+                    new_coltype.item_type = self._get_adapted_type(new_coltype.item_type, bind)
+
                 # If the adapted column type does not render the same as the original, don't
                 # substitute it
                 if new_coltype.compile(bind.dialect) != compiled_type:
-                    # Make an exception to the rule for Float, since at least on PostgreSQL,
-                    # Float can accurately represent both REAL and DOUBLE_PRECISION
-                    if not isinstance(new_coltype, Float):
+                    # Make an exception to the rule for Float and arrays of Float, since at least
+                    # on PostgreSQL, Float can accurately represent both REAL and DOUBLE_PRECISION
+                    if not isinstance(new_coltype, Float) and \
+                       not (isinstance(new_coltype, ARRAY) and
+                            isinstance(new_coltype.item_type, Float)):
                         break
-
-                if isinstance(coltype, ARRAY):
-                    new_coltype.item_type = self._get_adapted_type(new_coltype.item_type, bind)
 
                 # Stop on the first valid non-uppercase column type class
                 coltype = new_coltype

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -111,7 +111,7 @@ def test_arrays(metadata):
         assert generate_code(metadata) == """\
 # coding: utf-8
 from sqlalchemy import Column, Float, Integer, MetaData, Table
-from sqlalchemy.dialects.postgresql.base import ARRAY
+from sqlalchemy.dialects.postgresql import ARRAY
 
 metadata = MetaData()
 
@@ -1284,4 +1284,30 @@ class Simple(Base):
 
     id = Column(Integer, primary_key=True)
     timestamp = Column(TIMESTAMP)
+"""
+
+
+@pytest.mark.parametrize('metadata', ['mysql'], indirect=['metadata'])
+def test_mysql_integer_display_width(metadata):
+    Table(
+        'simple', metadata,
+        Column('id', INTEGER, primary_key=True),
+        Column('number', mysql.INTEGER(11))
+    )
+
+    assert generate_code(metadata) == """\
+# coding: utf-8
+from sqlalchemy import Column, Integer
+from sqlalchemy.dialects.mysql import INTEGER
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+metadata = Base.metadata
+
+
+class Simple(Base):
+    __tablename__ = 'simple'
+
+    id = Column(Integer, primary_key=True)
+    number = Column(INTEGER(11))
 """


### PR DESCRIPTION
If a vendor-specific type cannot be adapted to a generic sqlalchemy type then import the vendor-specific type rather than the generic type. Some vendor-specific types have different constructors. E.g., MySQL INTEGER, which can take a display width.

Fixes #67 
Potentially fixes #70 (not enough info in issue to know for sure)

The code was careful not to adapt column types further if they rendered differently from the adapted type, then imported the generic types anyway when the imports were rendered.

Note: I changed the < 1.1 test_arrays ARRAY import from:
`from sqlalchemy.dialects.postgresql.base import ARRAY`

to:
`from sqlalchemy.dialects.postgresql import ARRAY`