### PR TITLE
Added support for env var name as db url

### DIFF
--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals, division, print_function, absolute_impo
 import argparse
 import io
 import sys
+import os
 
 import pkg_resources
 from sqlalchemy.engine import create_engine
@@ -38,6 +39,12 @@ def main():
         print('You must supply a url\n', file=sys.stderr)
         parser.print_help()
         return
+
+    try:
+        url = os.getenv(args.url)
+        print('Using env var {}'.format(args.url))
+    except Exception as e:
+        url = args.url
 
     # Use reflection to fill in the metadata
     engine = create_engine(args.url)

--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -40,14 +40,10 @@ def main():
         parser.print_help()
         return
 
-    try:
-        url = os.getenv(args.url)
-        print('Using env var {}'.format(args.url))
-    except Exception as e:
-        url = args.url
+    url = os.getenv(args.url, default=args.url)
 
     # Use reflection to fill in the metadata
-    engine = create_engine(args.url)
+    engine = create_engine(url)
     metadata = MetaData(engine)
     tables = args.tables.split(',') if args.tables else None
     metadata.reflect(engine, args.schema, not args.noviews, tables)


### PR DESCRIPTION
I use this tool with pipenv.
If my db url is in my system/user envs I can do:
`pipenv run sqlacodegen --tables Employees %DB_URL%`
But if my DB_URL is inside a .env file that is loaded by pipenv this does not get translated to the actual value.

This pull just adds a try to get env var named `args.url`, if it does not exist, assume args.url is a normal url.