### PR TITLE
command line arg 'notables', logic, readme update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,7 @@ from each table. There are two circumstances in which a ``Table`` is generated i
 * the table has no primary key constraint (which is required by SQLAlchemy for every model class)
 * the table is an association table between two other tables (see below for the specifics)
 
+This behaviour can be overridden. If for some reason you need it to generate only classes, use the ``--notables`` option.
 
 Model class naming logic
 ------------------------

--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -329,7 +329,7 @@ class CodeGenerator(object):
 {models}"""
 
     def __init__(self, metadata, noindexes=False, noconstraints=False, nojoined=False,
-                 noinflect=False, noclasses=False, indentation='    ', model_separator='\n\n',
+                 noinflect=False, noclasses=False, notables=False, indentation='    ', model_separator='\n\n',
                  ignored_tables=('alembic_version', 'migrate_version'), table_model=ModelTable,
                  class_model=ModelClass,  template=None):
         super(CodeGenerator, self).__init__()
@@ -339,6 +339,7 @@ class CodeGenerator(object):
         self.nojoined = nojoined
         self.noinflect = noinflect
         self.noclasses = noclasses
+        self.notables = notables
         self.indentation = indentation
         self.model_separator = model_separator
         self.ignored_tables = ignored_tables
@@ -409,7 +410,10 @@ class CodeGenerator(object):
 
             # Only form model classes for tables that have a primary key and are not association
             # tables
-            if noclasses or not table.primary_key or table.name in association_tables:
+            if noclasses and notables:
+                print("\n\nPlease choose one of notables or noclasses but not both!!!\n\n")
+                raise Exception
+            if not notables and (noclasses or not table.primary_key or table.name in association_tables):
                 model = self.table_model(table)
             else:
                 model = self.class_model(table, links[table.name], self.inflect_engine,

--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -27,6 +27,8 @@ def main():
                         help="don't try to convert tables names to singular form")
     parser.add_argument('--noclasses', action='store_true',
                         help="don't generate classes, only tables")
+    parser.add_argument('--notables', action='store_true',
+                        help="don't generate tables, only classes")
     parser.add_argument('--outfile', help='file to write output to (default: stdout)')
     args = parser.parse_args()
 
@@ -48,5 +50,5 @@ def main():
     # Write the generated model code to the specified file or standard output
     outfile = io.open(args.outfile, 'w', encoding='utf-8') if args.outfile else sys.stdout
     generator = CodeGenerator(metadata, args.noindexes, args.noconstraints, args.nojoined,
-                              args.noinflect, args.noclasses)
+                              args.noinflect, args.noclasses, args.notables)
     generator.render(outfile)


### PR DESCRIPTION
I have created some code and added a line to the readme to address this issue:
https://github.com/agronholm/sqlacodegen/issues/57

It has been done in such a way that if no `--notables` argument is given, everything should run as it usually does. In ran the tests and got the same result on this fork and the master fork.

If any additional print statements or readme additions are needed to warn the user about using the `--notables` argument, I can add them, or write any additional tests.