### PR TITLE
Added '--nojson' option and generate asdict(), __repr__, __str__ .

### DIFF
--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -27,6 +27,8 @@ def main():
                         help="don't try to convert tables names to singular form")
     parser.add_argument('--noclasses', action='store_true',
                         help="don't generate classes, only tables")
+    parser.add_argument('--nojson', action='store_true',
+                        help="don't generate jsons")
     parser.add_argument('--outfile', help='file to write output to (default: stdout)')
     args = parser.parse_args()
 
@@ -48,5 +50,5 @@ def main():
     # Write the generated model code to the specified file or standard output
     outfile = io.open(args.outfile, 'w', encoding='utf-8') if args.outfile else sys.stdout
     generator = CodeGenerator(metadata, args.noindexes, args.noconstraints, args.nojoined,
-                              args.noinflect, args.noclasses)
+                              args.noinflect, args.noclasses, args.nojson)
     generator.render(outfile)


### PR DESCRIPTION
Hi, this patch add a '--nojson' option to NOT generate __repr__ and __str__ and asdict() methods for generated classes.
I haven't tested it too much except for the PostgreSQL database located at:
http://www.postgresqltutorial.com/postgresql-sample-database/
So, you probably want to change it to --json if you want to NOT generate those methods and only do that on purpose, the idea behind that is you can do testing using the python command line interpreter with the results comming from SqlAlchemy as explained in the Tip from https://docs.sqlalchemy.org/en/13/orm/tutorial.html#declare-a-mapping.
"The User class defines a __repr__() method, but note that is optional; we only implement it in this tutorial so that our examples show nicely formatted User objects."