### PR TITLE
Fixed server_default bug

### DIFF
--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -567,11 +567,11 @@ class CodeGenerator(object):
         if column.server_default:
             # The quote escaping does not cover pathological cases but should mostly work
             default_expr = self._get_compiled_expression(column.server_default.arg)
-            if '\n' in default_expr:
-                server_default = 'server_default=text("""\\\n{0}""")'.format(default_expr)
+            if '\\n' in default_expr:
+                server_default = 'server_default=text(\'\'{0}\'\')'.format(default_expr)
             else:
                 default_expr = default_expr.replace('"', '\\"')
-                server_default = 'server_default=text("{0}")'.format(default_expr)
+                server_default = 'server_default=text({0})'.format(default_expr)
 
         comment = getattr(column, 'comment', None)
         return 'Column({0})'.format(', '.join(


### PR DESCRIPTION
sqlacodegen "mysql+mysqldb://db_user:pwd@127.0.0.1/db_py_admin?charset=utf8" --outfile model.py --noinflect

test data：

`
CREATE TABLE `demo1_address` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
  `region` varchar(8) NOT NULL DEFAULT '86' COMMENT '所属区域码 CN',
  `address` varchar(200) DEFAULT 'abc: \\ndd' COMMENT '详细地址 街道门牌号',
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='联系地址信息表';

or

CREATE TABLE `demo1_address` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
  `region` varchar(8) NOT NULL DEFAULT '86' COMMENT '所属区域码 CN',
  `address` varchar(200) DEFAULT 'abc: \ndd' COMMENT '详细地址 街道门牌号',
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='联系地址信息表';
`

Modify previous results：
server_default=text("'86'")      and        server_default=text("'abc: \\ndd'"
`
class SysAddress(Base):
    __tablename__ = 'sys_address'

    id = Column(BIGINT(20), primary_key=True, comment='主键')
    region = Column(String(8), nullable=False, server_default=text("'86'"), comment='所属区域码 CN')
    address = Column(String(200), server_default=text("'abc: \\ndd'"), comment='详细地址 街道门牌号')
`

The modified result： 
server_default=text('86')   and    server_default=text('''abc: \\ndd''')
`
class SysAddress(Base):
    __tablename__ = 'sys_address'

    id = Column(BIGINT(20), primary_key=True, comment='主键')
    region = Column(String(8), nullable=False, server_default=text('86'), comment='所属区域码 CN')
    address = Column(String(200), server_default=text('''abc: \\ndd'''), comment='详细地址 街道门牌号')
`
