### PR TITLE
Add support for tablename prefix and custom naming functions

### DIFF
--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from importlib import import_module
 from inspect import ArgSpec
 from keyword import iskeyword
-from enum import Enum as PyEnum
 
 import sqlalchemy
 import sqlalchemy.exc
@@ -257,7 +256,7 @@ class ModelClass(Model):
             child.add_imports(collector)
 
 
-class RelationshipType(PyEnum):
+class RelationshipType():
     ONE_TO_ONE = "ONE_TO_ONE"
     MANY_TO_ONE = "MANY_TO_ONE"
     MANY_TO_MANY = "MANY_TO_MANY"

--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from importlib import import_module
 from inspect import ArgSpec
 from keyword import iskeyword
+from enum import Enum as PyEnum
 
 import sqlalchemy
 import sqlalchemy.exc
@@ -168,8 +169,11 @@ class ModelTable(Model):
 class ModelClass(Model):
     parent_name = 'Base'
 
-    def __init__(self, table, association_tables, inflect_engine, detect_joined, tableprefix):
+    def __init__(self, table, association_tables, inflect_engine, detect_joined, tableprefix,
+                 class_name_fn, rel_name_fn):
         super(ModelClass, self).__init__(table)
+        self.class_name_fn = class_name_fn
+        self.rel_name_fn = rel_name_fn
         self.name = self._tablename_to_classname(table.name, inflect_engine, tableprefix)
         self.children = []
         self.attributes = OrderedDict()
@@ -189,7 +193,7 @@ class ModelClass(Model):
                     self.parent_name = target_cls
                 else:
                     relationship_ = ManyToOneRelationship(self.name, target_cls, constraint,
-                                                          inflect_engine)
+                                                          inflect_engine, self.rel_name_fn)
                     self._add_attribute(relationship_.preferred_name, relationship_)
 
         # Add many-to-many relationships
@@ -199,16 +203,23 @@ class ModelClass(Model):
             fk_constraints.sort(key=_get_constraint_sort_key)
             target_cls = self._tablename_to_classname(
                 fk_constraints[1].elements[0].column.table.name, inflect_engine, tableprefix)
-            relationship_ = ManyToManyRelationship(self.name, target_cls, association_table)
+            relationship_ = ManyToManyRelationship(self.name, target_cls,
+                                                   association_table, self.rel_name_fn)
             self._add_attribute(relationship_.preferred_name, relationship_)
 
-    @classmethod
-    def _tablename_to_classname(cls, tablename, inflect_engine, tableprefix):
+    def _tablename_to_classname(self, tablename, inflect_engine, tableprefix):
         if tableprefix and tablename.startswith(tableprefix):
             tablename = tablename[len(tableprefix):]
-        tablename = cls._convert_to_valid_identifier(tablename)
-        camel_case_name = ''.join(part[:1].upper() + part[1:] for part in tablename.split('_'))
-        return inflect_engine.singular_noun(camel_case_name) or camel_case_name
+        class_name = None
+        if self.class_name_fn:
+            class_name = self.class_name_fn(tablename)
+
+        if class_name is None:
+            tablename = self._convert_to_valid_identifier(tablename)
+            camel_case_name = ''.join(part[:1].upper() + part[1:] for part in tablename.split('_'))
+            class_name = inflect_engine.singular_noun(camel_case_name) or camel_case_name
+
+        return class_name
 
     @staticmethod
     def _convert_to_valid_identifier(name):
@@ -236,8 +247,20 @@ class ModelClass(Model):
         if any(isinstance(value, Relationship) for value in self.attributes.values()):
             collector.add_literal_import('sqlalchemy.orm', 'relationship')
 
+        if any(isinstance(value, ManyToOneRelationship)
+               and value.is_one_to_one
+               and 'backref' in value.kwargs
+               for value in self.attributes.values()):
+            collector.add_literal_import('sqlalchemy.orm', 'backref')
+
         for child in self.children:
             child.add_imports(collector)
+
+
+class RelationshipType(PyEnum):
+    ONE_TO_ONE = "ONE_TO_ONE"
+    MANY_TO_ONE = "MANY_TO_ONE"
+    MANY_TO_MANY = "MANY_TO_MANY"
 
 
 class Relationship(object):
@@ -249,7 +272,7 @@ class Relationship(object):
 
 
 class ManyToOneRelationship(Relationship):
-    def __init__(self, source_cls, target_cls, constraint, inflect_engine):
+    def __init__(self, source_cls, target_cls, constraint, inflect_engine, rel_name_fn):
         super(ManyToOneRelationship, self).__init__(source_cls, target_cls)
 
         column_names = _get_column_names(constraint)
@@ -261,16 +284,33 @@ class ManyToOneRelationship(Relationship):
             self.preferred_name = colname[:-3]
 
         # Add uselist=False to One-to-One relationships
+        self.relationship_type = RelationshipType.MANY_TO_ONE
         if any(isinstance(c, (PrimaryKeyConstraint, UniqueConstraint)) and
                set(col.name for col in c.columns) == set(column_names)
                for c in constraint.table.constraints):
             self.kwargs['uselist'] = 'False'
+            self.relationship_type = RelationshipType.ONE_TO_ONE
 
         # Handle self referential relationships
         if source_cls == target_cls:
             self.preferred_name = 'parent' if not colname.endswith('_id') else colname[:-3]
             pk_col_names = [col.name for col in constraint.table.primary_key]
             self.kwargs['remote_side'] = '[{0}]'.format(', '.join(pk_col_names))
+
+        # if there's a custom relationship name, use that
+        if rel_name_fn is not None:
+            rel_and_backref_name = rel_name_fn(constraint, self.relationship_type)
+            if rel_and_backref_name is not None:
+                rel_name, backref_name = rel_and_backref_name
+                if rel_name is not None:
+                    self.preferred_name = rel_name
+                if backref_name is not None:
+                    if self.is_one_to_one:
+                        backref_arg = "backref('{}', uselist=False)".format(backref_name)
+                    else:
+                        backref_arg = "'{}'".format(backref_name)
+
+                    self.kwargs['backref'] = backref_arg
 
         # If the two tables share more than one foreign key constraint,
         # SQLAlchemy needs an explicit primaryjoin to figure out which column(s) to join with
@@ -279,6 +319,10 @@ class ManyToOneRelationship(Relationship):
         if len(common_fk_constraints) > 1:
             self.kwargs['primaryjoin'] = "'{0}.{1} == {2}.{3}'".format(
                 source_cls, column_names[0], target_cls, constraint.elements[0].column.name)
+
+    @property
+    def is_one_to_one(self):
+        return self.relationship_type == RelationshipType.ONE_TO_ONE
 
     @staticmethod
     def get_common_fk_constraints(table1, table2):
@@ -291,7 +335,7 @@ class ManyToOneRelationship(Relationship):
 
 
 class ManyToManyRelationship(Relationship):
-    def __init__(self, source_cls, target_cls, assocation_table):
+    def __init__(self, source_cls, target_cls, assocation_table, rel_name_fn):
         super(ManyToManyRelationship, self).__init__(source_cls, target_cls)
 
         prefix = (assocation_table.schema + '.') if assocation_table.schema else ''
@@ -321,6 +365,16 @@ class ManyToManyRelationship(Relationship):
                 repr('and_({0})'.format(', '.join(sec_joins)))
                 if len(sec_joins) > 1 else repr(sec_joins[0]))
 
+        # if there's a custom relationship name, use that
+        if rel_name_fn is not None:
+            rel_and_backref_name = rel_name_fn(constraints[1], RelationshipType.MANY_TO_MANY)
+            if rel_and_backref_name is not None:
+                rel_name, backref_name = rel_and_backref_name
+                if rel_name is not None:
+                    self.preferred_name = rel_name
+                if backref_name is not None:
+                    self.kwargs['backref'] = "'{}'".format(backref_name)
+
 
 class CodeGenerator(object):
     template = """\
@@ -335,7 +389,8 @@ class CodeGenerator(object):
     def __init__(self, metadata, noindexes=False, noconstraints=False, nojoined=False,
                  noinflect=False, noclasses=False, indentation='    ', model_separator='\n\n',
                  ignored_tables=('alembic_version', 'migrate_version'), table_model=ModelTable,
-                 class_model=ModelClass,  template=None, nocomments=False, tableprefix=''):
+                 class_model=ModelClass,  template=None, nocomments=False, tableprefix='',
+                 class_name_fn=None, rel_name_fn=None):
         super(CodeGenerator, self).__init__()
         self.metadata = metadata
         self.noindexes = noindexes
@@ -351,6 +406,8 @@ class CodeGenerator(object):
         self.nocomments = nocomments
         self.tableprefix = tableprefix
         self.inflect_engine = self.create_inflect_engine()
+        self.class_name_fn = class_name_fn
+        self.rel_name_fn = rel_name_fn
         if template:
             self.template = template
 
@@ -419,7 +476,8 @@ class CodeGenerator(object):
                 model = self.table_model(table)
             else:
                 model = self.class_model(table, links[table.name], self.inflect_engine,
-                                         not nojoined, self.tableprefix)
+                                         not nojoined, self.tableprefix, self.class_name_fn,
+                                         self.rel_name_fn)
                 classes[model.name] = model
 
             self.models.append(model)

--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -5,10 +5,17 @@ import io
 import sys
 
 import pkg_resources
+from importlib import import_module
 from sqlalchemy.engine import create_engine
 from sqlalchemy.schema import MetaData
 
 from sqlacodegen.codegen import CodeGenerator
+
+
+def get_function_from_module(fully_qualified_function_name):
+    module_name, function_name = fully_qualified_function_name.rsplit('.', 1)
+    module = import_module(module_name)
+    return getattr(module, function_name)
 
 
 def main():
@@ -30,6 +37,12 @@ def main():
                         help="don't generate classes, only tables")
     parser.add_argument('--nocomments', action='store_true', help="don't render column comments")
     parser.add_argument('--outfile', help='file to write output to (default: stdout)')
+    parser.add_argument('--classnamefn',
+                        help='''function to map table name to class name for custom class model
+                                naming''')
+    parser.add_argument('--relnamefn',
+                        help='''function to map foreign key constraint object to relationship name
+                                for custom relationship naming''')
     args = parser.parse_args()
 
     if args.version:
@@ -41,6 +54,16 @@ def main():
         parser.print_help()
         return 0
 
+    # Optional custom table naming function
+    class_name_fn = None
+    if args.classnamefn:
+        class_name_fn = get_function_from_module(args.classnamefn)
+
+    # Optional custom relationship naming function
+    rel_name_fn = None
+    if args.relnamefn:
+        rel_name_fn = get_function_from_module(args.relnamefn)
+
     # Use reflection to fill in the metadata
     engine = create_engine(args.url)
     metadata = MetaData(engine)
@@ -51,5 +74,6 @@ def main():
     outfile = io.open(args.outfile, 'w', encoding='utf-8') if args.outfile else sys.stdout
     generator = CodeGenerator(metadata, args.noindexes, args.noconstraints, args.nojoined,
                               args.noinflect, args.noclasses, nocomments=args.nocomments,
-                              tableprefix=args.tableprefix)
+                              tableprefix=args.tableprefix, class_name_fn=class_name_fn,
+                              rel_name_fn=rel_name_fn)
     generator.render(outfile)

--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -35,11 +35,11 @@ def main():
     if args.version:
         version = pkg_resources.get_distribution('sqlacodegen').parsed_version
         print(version.public)
-        return
+        return 0
     if not args.url:
         print('You must supply a url\n', file=sys.stderr)
         parser.print_help()
-        return
+        return 0
 
     # Use reflection to fill in the metadata
     engine = create_engine(args.url)

--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -18,6 +18,7 @@ def main():
     parser.add_argument('--version', action='store_true', help="print the version number and exit")
     parser.add_argument('--schema', help='load tables from an alternate schema')
     parser.add_argument('--tables', help='tables to process (comma-separated, default: all)')
+    parser.add_argument('--tableprefix', help='table prefix to ignore in generating class names')
     parser.add_argument('--noviews', action='store_true', help="ignore views")
     parser.add_argument('--noindexes', action='store_true', help='ignore indexes')
     parser.add_argument('--noconstraints', action='store_true', help='ignore constraints')
@@ -49,5 +50,5 @@ def main():
     # Write the generated model code to the specified file or standard output
     outfile = io.open(args.outfile, 'w', encoding='utf-8') if args.outfile else sys.stdout
     generator = CodeGenerator(metadata, args.noindexes, args.noconstraints, args.nojoined,
-                              args.noinflect, args.noclasses, nocomments=args.nocomments)
+                              args.noinflect, args.noclasses, nocomments=args.nocomments, tableprefix=args.tableprefix)
     generator.render(outfile)

--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -50,5 +50,6 @@ def main():
     # Write the generated model code to the specified file or standard output
     outfile = io.open(args.outfile, 'w', encoding='utf-8') if args.outfile else sys.stdout
     generator = CodeGenerator(metadata, args.noindexes, args.noconstraints, args.nojoined,
-                              args.noinflect, args.noclasses, nocomments=args.nocomments, tableprefix=args.tableprefix)
+                              args.noinflect, args.noclasses, nocomments=args.nocomments,
+                              tableprefix=args.tableprefix)
     generator.render(outfile)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1698,12 +1698,13 @@ backref=backref('item', uselist=False))
 
 def test_onetoone_rel_name_relationship_type_arg(metadata):
     """Test the correct relationship type is passed into the relationship naming function."""
-    actual_relationship_type = None
-    expected_relationship_type = RelationshipType.ONE_TO_ONE
+    class context:
+        actual_relationship_type = None
+        expected_relationship_type = RelationshipType.ONE_TO_ONE    
 
-    def rel_name_fn(foreign_key_constraint, relationship_type):
-        nonlocal actual_relationship_type
-        actual_relationship_type = relationship_type
+    def rel_name_fn(foreign_key_constraint, relationship_type):        
+        #nonlocal actual_relationship_type
+        context.actual_relationship_type = relationship_type
         return None
 
     Table(
@@ -1719,17 +1720,18 @@ def test_onetoone_rel_name_relationship_type_arg(metadata):
     )
 
     generate_code(metadata, rel_name_fn=rel_name_fn)
-    assert(actual_relationship_type == expected_relationship_type)
+    assert(context.actual_relationship_type == context.expected_relationship_type)
 
 
 def test_manytoone_rel_name_relationship_type_arg(metadata):
     """Test the correct relationship type is passed into the relationship naming function."""
-    actual_relationship_type = None
-    expected_relationship_type = RelationshipType.MANY_TO_ONE
+    class context:
+        actual_relationship_type = None
+        expected_relationship_type = RelationshipType.MANY_TO_ONE
 
     def rel_name_fn(foreign_key_constraint, relationship_type):
-        nonlocal actual_relationship_type
-        actual_relationship_type = relationship_type
+        #nonlocal actual_relationship_type
+        context.actual_relationship_type = relationship_type
         return None
 
     Table(
@@ -1744,17 +1746,18 @@ def test_manytoone_rel_name_relationship_type_arg(metadata):
     )
 
     generate_code(metadata, rel_name_fn=rel_name_fn)
-    assert(actual_relationship_type == expected_relationship_type)
+    assert(context.actual_relationship_type == context.expected_relationship_type)
 
 
 def test_manytomany_rel_name_relationship_type_arg(metadata):
     """Test the correct relationship type is passed into the relationship naming function."""
-    actual_relationship_type = None
-    expected_relationship_type = RelationshipType.MANY_TO_MANY
+    class context:
+        actual_relationship_type = None
+        expected_relationship_type = RelationshipType.MANY_TO_MANY
 
     def rel_name_fn(foreign_key_constraint, relationship_type):
-        nonlocal actual_relationship_type
-        actual_relationship_type = relationship_type
+        #nonlocal actual_relationship_type
+        context.actual_relationship_type = relationship_type
         return None
 
     Table(
@@ -1774,4 +1777,4 @@ def test_manytomany_rel_name_relationship_type_arg(metadata):
     )
 
     generate_code(metadata, rel_name_fn=rel_name_fn)
-    assert(actual_relationship_type == expected_relationship_type)
+    assert(context.actual_relationship_type == context.expected_relationship_type)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -47,6 +47,12 @@ def generate_code(metadata, **kwargs):
     return remove_unicode_prefixes(sio.getvalue())
 
 
+def test_main_invoke():
+    from sqlacodegen.main import main
+    result = main()
+    assert result == 0
+
+
 @pytest.mark.parametrize('metadata', ['postgresql'], indirect=['metadata'])
 def test_fancy_coltypes(metadata):
     Table(

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1700,10 +1700,10 @@ def test_onetoone_rel_name_relationship_type_arg(metadata):
     """Test the correct relationship type is passed into the relationship naming function."""
     class context:
         actual_relationship_type = None
-        expected_relationship_type = RelationshipType.ONE_TO_ONE    
+        expected_relationship_type = RelationshipType.ONE_TO_ONE
 
-    def rel_name_fn(foreign_key_constraint, relationship_type):        
-        #nonlocal actual_relationship_type
+    def rel_name_fn(foreign_key_constraint, relationship_type):
+        # nonlocal actual_relationship_type
         context.actual_relationship_type = relationship_type
         return None
 
@@ -1730,7 +1730,7 @@ def test_manytoone_rel_name_relationship_type_arg(metadata):
         expected_relationship_type = RelationshipType.MANY_TO_ONE
 
     def rel_name_fn(foreign_key_constraint, relationship_type):
-        #nonlocal actual_relationship_type
+        # nonlocal actual_relationship_type
         context.actual_relationship_type = relationship_type
         return None
 
@@ -1756,7 +1756,7 @@ def test_manytomany_rel_name_relationship_type_arg(metadata):
         expected_relationship_type = RelationshipType.MANY_TO_MANY
 
     def rel_name_fn(foreign_key_constraint, relationship_type):
-        #nonlocal actual_relationship_type
+        # nonlocal actual_relationship_type
         context.actual_relationship_type = relationship_type
         return None
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -846,6 +846,44 @@ class SimpleSubItem(SimpleItem):
 """
 
 
+def test_tableprefix(metadata):
+    Table(
+        'prefix_test_table', metadata,
+        Column('id', INTEGER, primary_key=True),
+        Column('container_id', INTEGER),
+        ForeignKeyConstraint(['container_id'], ['prefix_container_table.id']),
+    )
+    Table(
+        'prefix_container_table', metadata,
+        Column('id', INTEGER, primary_key=True)
+    )
+
+    assert generate_code(metadata, tableprefix='prefix_') == """\
+# coding: utf-8
+from sqlalchemy import Column, ForeignKey, Integer
+from sqlalchemy.orm import relationship
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+metadata = Base.metadata
+
+
+class ContainerTable(Base):
+    __tablename__ = 'prefix_container_table'
+
+    id = Column(Integer, primary_key=True)
+
+
+class TestTable(Base):
+    __tablename__ = 'prefix_test_table'
+
+    id = Column(Integer, primary_key=True)
+    container_id = Column(ForeignKey('prefix_container_table.id'))
+
+    container = relationship('ContainerTable')
+"""
+
+
 def test_no_inflect(metadata):
     Table(
         'simple_items', metadata,


### PR DESCRIPTION
In many legacy databases it is quite customary to have table names prefixed with some prefix. There are many other reasons for which such prefixes are used. For example it is quite normal to see WordPress database tables prefixed with wp_
When code is generated for such database tables, the prefix becomes part of the class name. Which in fact is not desirable. This update allows us to ignore the specified prefix in generating the class names.

Example: **wp_** is a prefix to ignore.
If table name is **wp_user**, the standard code generation will generate class name **WpUser**. The modified code when passed with command line parameter ** --tableprefix  wp_** will generate class name **User**

### **Update:**
This pull request now incorporates the custom class naming functions feature implemented by pull request #76.