### PR TITLE
Fix for issue #71

### DIFF
--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -603,8 +603,8 @@ class CodeGenerator(object):
         return rendered + delimiter.join(args) + end
 
     def render_table(self, model):
-        rendered = 't_{0} = Table(\n{1}{0!r}, metadata,\n'.format(
-            model.name, self.indentation)
+        rendered = 't_{0} = Table(\n{2}{1!r}, metadata,\n'.format(
+            model.name, model.table.name, self.indentation)
 
         for column in model.table.columns:
             rendered += '{0}{1},\n'.format(self.indentation, self.render_column(column, True))

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1293,7 +1293,7 @@ def test_table_comment(metadata):
         comment="this is a 'comment'"
     )
 
-    codegen = CodeGenerator(metadata)
+    codegen = CodeGenerator(metadata, noclasses=True)
     code = codegen.render_table(codegen.models[0])
     assert code == """\
 t_simple = Table(

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1467,5 +1467,3 @@ t_simple_items_table = Table(
     Column('id', Integer, primary_key=True)
 )
 """
-
-

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1447,3 +1447,25 @@ class Simple(Base):
     id = Column(Integer, primary_key=True)
     my_longtext = Column(LONGTEXT)
 """
+
+
+def test_table_name_identifiers(metadata):
+    Table(
+        'simple-items table', metadata,
+        Column('id', INTEGER, primary_key=True)
+    )
+
+    assert generate_code(metadata, noclasses=True) == """\
+# coding: utf-8
+from sqlalchemy import Column, Integer, MetaData, Table
+
+metadata = MetaData()
+
+
+t_simple_items_table = Table(
+    'simple-items table', metadata,
+    Column('id', Integer, primary_key=True)
+)
+"""
+
+


### PR DESCRIPTION
Issues with table name identifiers getting generated with invalid characters has been fixed. 
Identifiers will now match the [A-Za-z0-9_] specs.