### PR TITLE
Add extra 'citext' to add support for CIText  and CIText arrays on PostgreSQL database

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,10 @@ To install, do::
 
     pip install sqlacodegen
 
+To include support for the PostgreSQL `CITEXT` extension type (which should be considered as tested only under a few environments) specify the `citext` extra::
+
+    pip install sqlacodegen[citext]
+
 
 Example usage
 -------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ test =
     pytest-cov
     psycopg2-binary
     mysql-connector-python
+citext = sqlalchemy-citext >= 1.7.0
 
 [options.entry_points]
 console_scripts =

--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -19,12 +19,6 @@ from sqlalchemy.sql.sqltypes import NullType
 from sqlalchemy.types import Boolean, String
 from sqlalchemy.util import OrderedDict
 
-# Support CIText and CIText[] in PostgreSQL via sqlalchemy-citext
-try:
-    from citext import CIText  # noqa: F401
-except (NameError, ImportError):
-    pass
-
 # The generic ARRAY type was introduced in SQLAlchemy 1.1
 try:
     from sqlalchemy import ARRAY
@@ -40,6 +34,12 @@ except ImportError:
 # Conditionally import Geoalchemy2 to enable reflection support
 try:
     import geoalchemy2  # noqa: F401
+except ImportError:
+    pass
+
+# Support CIText and CIText[] in PostgreSQL via sqlalchemy-citext
+try:
+    import citext  # noqa: F401
 except ImportError:
     pass
 

--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -21,7 +21,7 @@ from sqlalchemy.util import OrderedDict
 
 # Support CIText and CIText[] in PostgreSQL via sqlalchemy-citext
 try:
-    from citext import CIText
+    from citext import CIText  # noqa: F401
 except (NameError, ImportError):
     pass
 

--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -19,6 +19,12 @@ from sqlalchemy.sql.sqltypes import NullType
 from sqlalchemy.types import Boolean, String
 from sqlalchemy.util import OrderedDict
 
+# Support CIText and CIText[] in PostgreSQL via sqlalchemy-citext
+try:
+    from citext import CIText
+except (NameError, ImportError):
+    pass
+
 # The generic ARRAY type was introduced in SQLAlchemy 1.1
 try:
     from sqlalchemy import ARRAY


### PR DESCRIPTION
After entering #124, I took a quick look at this and saw that it was pretty trivial to add. I added it as an optional / extra so it can be installed using `pip install sqlacodegen[citext]` without impacting users that don't want or need it

Is this something you'll take upstream?

Thanks!