### PR TITLE
oursql does not work correctly with the python3. Better to use pymysq…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ instructions on how to construct a proper URL.
 Examples::
 
     sqlacodegen postgresql:///some_local_db
-    sqlacodegen mysql+oursql://user:password@localhost/dbname
+    sqlacodegen mysql+pymysql://user:password@localhost/dbname
     sqlacodegen sqlite:///database.db
 
 To see the full list of options::


### PR DESCRIPTION
oursql bad works (install!!!) in python 3
I try pymysql, works, but may be not in all scenarios

Collecting oursql
  Downloading oursql-0.9.3.2.tar.gz (187 kB)
...
      File "C:\Temp\pip-install-crfq2xsi\oursql\setup.py", line 53
        print "cython not found, using previously-cython'd .c file."
              ^
    SyntaxError: Missing parentheses in call to 'print'. Did you mean print("cython not found, using previously-cython'd .c file.")?
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.