### PR TITLE
Included auto-increment to column generation

### DIFF
--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -334,6 +334,8 @@ class TablesGenerator(CodeGenerator):
             kwargs['primary_key'] = True
         if not column.nullable and not is_sole_pk:
             kwargs['nullable'] = False
+        if column.autoincrement == True:
+            kwargs['autoincrement'] = True
 
         if is_unique:
             column.unique = True

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -482,6 +482,24 @@ t_simple_items = Table(
 )
 """
 
+    def test_autoincrement(self, generator: CodeGenerator) -> None:
+        Table(
+            'simple_items', generator.metadata,
+            Column('id', INTEGER, primary_key=True, autoincrement=True)
+        )
+
+        assert generator.generate() == """\
+from sqlalchemy import Column, Integer, MetaData, Table
+
+metadata = MetaData()
+
+
+t_simple_items = Table(
+    'simple_items', metadata,
+    Column('id', Integer, primary_key=True, autoincrement=True)
+)
+"""
+
     @pytest.mark.parametrize('engine', ['mysql'], indirect=['engine'])
     def test_mysql_timestamp(self, generator: CodeGenerator) -> None:
         Table(


### PR DESCRIPTION
This is to fix the issue in #122
I have tested this with both mysql and postgres.
The output from postgres is the following which matches what was originally expected.
```
class DjangoMigrations(Base):
    __tablename__ = 'django_migrations'

    id = Column(Integer, primary_key=True, autoincrement=True, server_default=text("nextval('django_migrations_id_seq'::regclass)"))
```