### PR TITLE
Force pk

### DIFF
--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -591,18 +591,32 @@ class DeclarativeGenerator(TablesGenerator):
                 links[tablename].append(model)
                 continue
 
-            # Only form model classes for tables that have a primary key and are not association
+            # Form model classes for tables that have a primary key and are not association
             # tables
             if not table.primary_key:
-                models_by_table_name[table.name] = Model(table)
-            else:
-                model = ModelClass(table)
-                models_by_table_name[table.name] = model
+                first_col_name = table.c.values()[0].name
+                pk = PrimaryKeyConstraint('forced_pk', first_col_name)
+                table.append_constraint(pk)
+            model = ModelClass(table)
+            models_by_table_name[table.name] = model
 
-                # Fill in the columns
-                for column in table.c:
-                    column_attr = ColumnAttribute(model, column)
-                    model.columns.append(column_attr)
+            # Fill in the columns
+            for column in table.c:
+                column_attr = ColumnAttribute(model, column)
+                model.columns.append(column_attr)
+
+            # Only form model classes for tables that have a primary key and are not association
+            # tables
+            # if not table.primary_key:
+            #     models_by_table_name[table.name] = Model(table)
+            # else:
+            #     model = ModelClass(table)
+            #     models_by_table_name[table.name] = model
+            #
+            #     # Fill in the columns
+            #     for column in table.c:
+            #         column_attr = ColumnAttribute(model, column)
+            #         model.columns.append(column_attr)
 
         # Add relationships
         for model in models_by_table_name.values():

--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -595,7 +595,7 @@ class DeclarativeGenerator(TablesGenerator):
             # tables
             if not table.primary_key:
                 first_col_name = table.c.values()[0].name
-                pk = PrimaryKeyConstraint('forced_pk', first_col_name)
+                pk = PrimaryKeyConstraint(first_col_name)
                 table.append_constraint(pk)
             model = ModelClass(table)
             models_by_table_name[table.name] = model


### PR DESCRIPTION
## What?
I've added an **option** _"forcepk"_ for **DeclarativeGenerator**.
If there is no primary key it forces it on the **first column** and makes a model
## Why?
This change may be helpful for people who want to get a model out of **view**
## How?
This includes an added option _"forcepk"_ in **valid_options**, and if else statement for chekcing whether it has primary key or not.
With **append_constraint** method it forces pk on first column, if such option was chosen
```
if 'forcepk' in self.options:
    if not table.primary_key:
        first_col_name = table.c.values()[0].name
        pk = PrimaryKeyConstraint(first_col_name)
        table.append_constraint(pk)
```
## Testing
I haven't added tests for it yet, but it won't be much a problem to do them