### PR TITLE
Restore CITEXT, Geoalchemy2 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,12 @@ considered as tested only under a few environments) specify the ``citext`` extra
     pip install sqlacodegen[citext]
 
 
+To include support for the PostgreSQL ``GEOMETRY``, ``GEOGRAPHY``, and ``RASTER`` types (which should be
+considered as tested only under a few environments) specify the ``geoalchemy2`` extra::
+    pip install sqlacodegen[geoalchemy2]
+
+
+
 Quickstart
 ==========
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ citext = ["sqlalchemy-citext >= 1.7.0"]
 geoalchemy2 = ["geoalchemy2 >= 0.11.1"]
 
 [project.entry-points."sqlacodegen.generators"]
-
 tables = "sqlacodegen.generators:TablesGenerator"
 declarative = "sqlacodegen.generators:DeclarativeGenerator"
 dataclasses = "sqlacodegen.generators:DataclassGenerator"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,10 @@ test = [
     "sqlmodel",
 ]
 citext = ["sqlalchemy-citext >= 1.7.0"]
+geoalchemy2 = ["geoalchemy2 >= 0.11.1"]
 
 [project.entry-points."sqlacodegen.generators"]
+
 tables = "sqlacodegen.generators:TablesGenerator"
 declarative = "sqlacodegen.generators:DeclarativeGenerator"
 dataclasses = "sqlacodegen.generators:DataclassGenerator"

--- a/src/sqlacodegen/cli.py
+++ b/src/sqlacodegen/cli.py
@@ -8,6 +8,16 @@ from typing import TextIO
 from sqlalchemy.engine import create_engine
 from sqlalchemy.schema import MetaData
 
+try:
+    import citext
+except ImportError:
+    citext = None
+
+try:
+    import geoalchemy2
+except ImportError:
+    geoalchemy2 = None
+
 if sys.version_info < (3, 10):
     from importlib_metadata import entry_points, version
 else:
@@ -49,6 +59,12 @@ def main() -> None:
         print("You must supply a url\n", file=sys.stderr)
         parser.print_help()
         return
+
+    if citext:
+        print(f"Using sqlalchemy-citext {citext.__version__}")
+
+    if geoalchemy2:
+        print(f"Using geoalchemy2 {geoalchemy2.__version__}")
 
     # Use reflection to fill in the metadata
     engine = create_engine(args.url)


### PR DESCRIPTION
While experimenting with 3.0.0-rc1 of sqlacodegen I noticed that geoalchemy and sqlalchemy-citext support seemed to be broken.

This PR restores the functionality by importing them if they are available in the cli module where the sqlalchemy metadata is populated via reflection.

This PR also creates a new extra for geoalchemy types and adds some print statements asserting that the libraries loaded correctly (mostly to avoid unused import errors from pyflake, but doubles as confirmation for end-users)