### PR TITLE
Extend fix for #205 to cover relationships, fix incorrect plural relationship names

### DIFF
--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -998,13 +998,16 @@ class DeclarativeGenerator(TablesGenerator):
                         preferred_name = column_names[0][:-3]
 
             if "use_inflect" in self.options:
+                # plural_noun expects a singular noun, so we should always try to
+                # convert the table name to singular first
+                singular_name = self.inflect_engine.singular_noun(preferred_name)
+                if singular_name:
+                    preferred_name = singular_name
                 if relationship.type in (
                     RelationshipType.ONE_TO_MANY,
                     RelationshipType.MANY_TO_MANY,
                 ):
                     preferred_name = self.inflect_engine.plural_noun(preferred_name)
-                else:
-                    preferred_name = self.inflect_engine.singular_noun(preferred_name)
 
         relationship.name = self.find_free_name(
             preferred_name, global_names, local_names

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1822,6 +1822,90 @@ class Singular(Base):
             """,
         )
 
+    @pytest.mark.parametrize("generator", [["use_inflect"]], indirect=True)
+    def test_use_inflect_relationship_singular(self, generator: CodeGenerator) -> None:
+        Table(
+            "simple_items",
+            generator.metadata,
+            Column("id", INTEGER, primary_key=True),
+            Column("container_id", INTEGER),
+            ForeignKeyConstraint(["container_id"], ["singular_container.id"]),
+        )
+        Table(
+            "singular_container",
+            generator.metadata,
+            Column("id", INTEGER, primary_key=True),
+        )
+
+        validate_code(
+            generator.generate(),
+            """\
+from sqlalchemy import Column, ForeignKey, Integer
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class SingularContainer(Base):
+    __tablename__ = 'singular_container'
+
+    id = Column(Integer, primary_key=True)
+
+    simple_items = relationship('SimpleItem', back_populates='container')
+
+
+class SimpleItem(Base):
+    __tablename__ = 'simple_items'
+
+    id = Column(Integer, primary_key=True)
+    container_id = Column(ForeignKey('singular_container.id'))
+
+    container = relationship('SingularContainer', back_populates='simple_items')
+            """,
+        )
+
+    @pytest.mark.parametrize("generator", [["use_inflect"]], indirect=True)
+    def test_use_inflect_relationship_plural(self, generator: CodeGenerator) -> None:
+        Table(
+            "simple_items",
+            generator.metadata,
+            Column("id", INTEGER, primary_key=True),
+            Column("container_id", INTEGER),
+            ForeignKeyConstraint(["container_id"], ["simple_containers.id"]),
+        )
+        Table(
+            "simple_containers",
+            generator.metadata,
+            Column("id", INTEGER, primary_key=True),
+        )
+
+        validate_code(
+            generator.generate(),
+            """\
+from sqlalchemy import Column, ForeignKey, Integer
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class SimpleContainer(Base):
+    __tablename__ = 'simple_containers'
+
+    id = Column(Integer, primary_key=True)
+
+    simple_items = relationship('SimpleItem', back_populates='container')
+
+
+class SimpleItem(Base):
+    __tablename__ = 'simple_items'
+
+    id = Column(Integer, primary_key=True)
+    container_id = Column(ForeignKey('simple_containers.id'))
+
+    container = relationship('SimpleContainer', back_populates='simple_items')
+            """,
+        )
+
     def test_table_kwargs(self, generator: CodeGenerator) -> None:
         Table(
             "simple_items",


### PR DESCRIPTION
Just squashing two bugs =)

The first one is just #205 but in a new and exciting place, the second is inflect 5.6.0 attempting to make an already plural table name... even more plural

On master:
* test_use_inflect_relationship_singular fails with an attribute error, per #205
* test_use_inflect_relationship_plural fails by generating a relationship with the name 'simple_itemss'

Both issues are fixed by this PR