### PR TITLE
Fixes #208: Preserve table name in SQLModels

### DIFF
--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -1407,13 +1407,7 @@ class SQLModelGenerator(DeclarativeGenerator):
         return f"class {model.name}{superclass_part}:"
 
     def render_class_variables(self, model: ModelClass) -> str:
-        # Render constraints and indexes as __table_args__
-        table_args = self.render_table_args(model.table)
-        if table_args:
-            variables = [f"__table_args__ = {table_args}"]
-            return "".join(variables)
-
-        return ""
+        return super().render_class_variables(model)
 
     def render_column_attribute(self, column_attr: ColumnAttribute) -> str:
         column = column_attr.column

--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -1426,10 +1426,16 @@ class SQLModelGenerator(DeclarativeGenerator):
             kwargs["default"] = None
             python_type_name = f"Optional[{python_type_name}]"
 
+        column_name = column_attr.name
+        if column_name.startswith("_"):
+            print(f"aliasing {column_name}")
+            kwargs["alias"] = f"'{column_name}'"
+            column_name = column_name.lstrip("_")
+
         rendered_column = self.render_column(column, True)
         kwargs["sa_column"] = f"{rendered_column}"
         rendered_field = render_callable("Field", kwargs=kwargs)
-        return f"{column_attr.name}: {python_type_name} = {rendered_field}"
+        return f"{column_name}: {python_type_name} = {rendered_field}"
 
     def render_relationship(self, relationship: RelationshipAttribute) -> str:
         rendered = super().render_relationship(relationship).partition(" = ")[2]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,6 +157,8 @@ from sqlalchemy import Column, Integer, Text
 from sqlmodel import Field, SQLModel
 
 class Foo(SQLModel, table=True):
+    __tablename__ = 'foo'
+
     id: Optional[int] = Field(default=None, sa_column=Column('id', Integer, \
 primary_key=True))
     name: str = Field(sa_column=Column('name', Text, nullable=False))

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -2608,6 +2608,7 @@ class TestSQLModelGenerator:
             from sqlmodel import Field, SQLModel
 
             class SimpleItems(SQLModel, table=True):
+                __tablename__ = 'simple_items'
                 __table_args__ = (
                     Index('idx_number', 'number'),
                     Index('idx_text', 'text', unique=True),
@@ -2642,6 +2643,7 @@ class TestSQLModelGenerator:
             from sqlmodel import Field, SQLModel
 
             class SimpleConstraints(SQLModel, table=True):
+                __tablename__ = 'simple_constraints'
                 __table_args__ = (
                     CheckConstraint('number > 0'),
                     UniqueConstraint('id', 'number')
@@ -2677,6 +2679,8 @@ class TestSQLModelGenerator:
             from sqlmodel import Field, Relationship, SQLModel
 
             class SimpleContainers(SQLModel, table=True):
+                __tablename__ = 'simple_containers'
+
                 id: Optional[int] = Field(default=None, sa_column=Column(\
 'id', Integer, primary_key=True))
 
@@ -2685,6 +2689,8 @@ back_populates='container')
 
 
             class SimpleGoods(SQLModel, table=True):
+                __tablename__ = 'simple_goods'
+
                 id: Optional[int] = Field(default=None, sa_column=Column(\
 'id', Integer, primary_key=True))
                 container_id: Optional[int] = Field(default=None, sa_column=Column(\
@@ -2717,6 +2723,8 @@ back_populates='simple_goods')
             from sqlmodel import Field, Relationship, SQLModel
 
             class OtherItems(SQLModel, table=True):
+                __tablename__ = 'other_items'
+
                 id: Optional[int] = Field(default=None, sa_column=Column(\
 'id', Integer, primary_key=True))
 
@@ -2725,6 +2733,8 @@ sa_relationship_kwargs={'uselist': False}, back_populates='other_item')
 
 
             class SimpleOnetoone(SQLModel, table=True):
+                __tablename__ = 'simple_onetoone'
+
                 id: Optional[int] = Field(default=None, sa_column=Column(\
 'id', Integer, primary_key=True))
                 other_item_id: Optional[int] = Field(default=None, sa_column=Column(\


### PR DESCRIPTION
This applies the `__tablename__` class variable to generated SQLModels