### PR TITLE
Refactor caused citext import to get lost

### DIFF
--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -68,7 +68,7 @@ else:
     from importlib.metadata import version
 
 try:
-    from citext import CIText
+    import citext  # noqa: F401
 except ImportError:
     pass
 

--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -69,7 +69,7 @@ else:
 
 try:
     from citext import CIText
-except (NameError, ImportError):
+except ImportError:
     pass
 
 _sqla_version = tuple(int(x) for x in version("sqlalchemy").split(".")[:2])

--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -67,6 +67,11 @@ if sys.version_info < (3, 10):
 else:
     from importlib.metadata import version
 
+try:
+    from citext import CIText
+except (NameError, ImportError):
+    pass
+
 _sqla_version = tuple(int(x) for x in version("sqlalchemy").split(".")[:2])
 _re_boolean_check_constraint = re.compile(r"(?:.*?\.)?(.*?) IN \(0, 1\)")
 _re_column_name = re.compile(r'(?:(["`]?).*\1\.)?(["`]?)(.*)\2')


### PR DESCRIPTION
https://github.com/agronholm/sqlacodegen/pull/125 added seamless support for `citext` when using `psycopg2` and `sqlalchemy`. The import is required to register the type with `psycopg2`. It got dropped during the refactor. This adds it back so users don't have to explicitly import it themselves