### PR TITLE
Handle inflect not changing a relationship name.

### DIFF
--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -1002,9 +1002,13 @@ class DeclarativeGenerator(TablesGenerator):
                     RelationshipType.ONE_TO_MANY,
                     RelationshipType.MANY_TO_MANY,
                 ):
-                    preferred_name = self.inflect_engine.plural_noun(preferred_name)
+                    inflected_name = self.inflect_engine.plural_noun(preferred_name)
+                    if inflected_name:
+                        preferred_name = inflected_name
                 else:
-                    preferred_name = self.inflect_engine.singular_noun(preferred_name)
+                    inflected_name = self.inflect_engine.singular_noun(preferred_name)
+                    if inflected_name:
+                        preferred_name = inflected_name
 
         relationship.name = self.find_free_name(
             preferred_name, global_names, local_names


### PR DESCRIPTION
BEFORE: If inflect did not change the `preferred_name` for a relationship, the code still overwrote the `preferred_name` (which caused an error when it later triped to invoke `.strip()` on `False`). This broke usage for cases where table names are pluralized, but FK columns are singular, e.g., `users.account_id -> accounts.id`.

AFTER: The relationship naming code uses the pattern from the model naming code to only overwrite the `preferred_name` when inflect hands back a truthy value.