### PR TITLE
Update generators.py

### DIFF
--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -68,9 +68,9 @@ else:
     from importlib.metadata import version
 
 _sqla_version = tuple(int(x) for x in version("sqlalchemy").split(".")[:2])
-_re_boolean_check_constraint = re.compile(r"(?:.*?\.)?(.*?) IN \(0, 1\)")
+_re_boolean_check_constraint = re.compile(r"(?:.*?\.)?(.*?)\s+IN\s*\(0, 1\)")   
 _re_column_name = re.compile(r'(?:(["`]?).*\1\.)?(["`]?)(.*)\2')
-_re_enum_check_constraint = re.compile(r"(?:.*?\.)?(.*?) IN \((.+)\)")
+_re_enum_check_constraint = re.compile(r"(?:.*?\.)?(.*?)\s+IN\s*\((.+)\)")      
 _re_enum_item = re.compile(r"'(.*?)(?<!\\)'")
 _re_invalid_identifier = re.compile(r"(?u)\W")
 


### PR DESCRIPTION
Allow for spaces in a constraint for enums:

For example, if your constraints was `CHECK IN('a', 'b', 'c')`, this would not be recognized.