### PR TITLE
Fix Column and metadata in SQLModel Generator

### DIFF
--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -1616,7 +1616,7 @@ class SQLModelGenerator(DeclarativeGenerator):
             kwargs["default"] = None
             python_type_name = f"Optional[{python_type_name}]"
 
-        rendered_column = self.render_column(column, True)
+        rendered_column = self.render_column(column, True, is_table=True)
         kwargs["sa_column"] = f"{rendered_column}"
         rendered_field = render_callable("Field", kwargs=kwargs)
         return f"{column_attr.name}: {python_type_name} = {rendered_field}"


### PR DESCRIPTION
I encountered a similar problem with #302 and I tried to fix it, including

- Force to use `Column` instead of `mapped_column`, through passing `is_table=True`
- Modify `generate_base` to generate `metadata` variable if `Model` exists

Maybe we can also refactor `generate_models` to decouple the function of getting `models` and collecting imports.

It is probably just a temporary solution to the issue. Thus it's up to you whether to merge. Thanks.