### PR TITLE
Import all 3rd party modules with an extra `_module` prefix 

### DIFF
--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -306,7 +306,8 @@ class TablesGenerator(CodeGenerator):
             collection.append(f"from {package} import {imports}")
 
         for module in sorted(self.module_imports):
-            thirdparty_imports.append(f"import {module}")
+            # all third-party module references must include a `_module` prefix to avoid collision with field names
+            thirdparty_imports.append(f"import {module} as {module}_module")
 
         return [
             group
@@ -1192,7 +1193,7 @@ class DeclarativeGenerator(TablesGenerator):
                 column_python_type = python_type_name
             else:
                 python_type_module = python_type.__module__
-                column_python_type = f"{python_type_module}.{python_type_name}"
+                column_python_type = f"{python_type_module}_module.{python_type_name}"
                 self.add_module_import(python_type_module)
         except NotImplementedError:
             self.add_literal_import("typing", "Any")


### PR DESCRIPTION
This solves an issue which specifically affects the uuid classes (as explained here https://github.com/agronholm/sqlacodegen/issues/331), but can generally affect any conflict in field name vs import.
What this PR do is add the prefix `_module` to any third-party imports, so for the case of uuid, it would result in a schema like:

```
import uuid as uuid_module
[...]
class SomeTable(Base):
  uuid: Mapped[uuid_module.uuid] = mapped_column(Uuid)

```
The third-party modules are used in two locations as can be seen in the compare. A better way to solve this would be to have some mapping instead a set, such as:
```
{"real module name": "imported as module name"}
```
but it would require bigger changes - this method works and is simple