### PR TITLE
Handle TextClause objects in DOMAIN expressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "SQLAlchemy >= 2.0.23",
+    "SQLAlchemy >= 2.0.29",
     "inflect >= 4.0.0",
     "importlib_metadata; python_version < '3.10'",
 ]

--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -38,7 +38,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import DOMAIN, JSONB
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import CompileError
 from sqlalchemy.sql.elements import TextClause
@@ -222,6 +222,13 @@ class TablesGenerator(CodeGenerator):
                 or column.type.astext_type.length is not None
             ):
                 self.add_import(column.type.astext_type)
+        elif isinstance(column.type, DOMAIN):
+            self.add_import(column.type.data_type.__class__)
+            if (
+                isinstance(column.type.default, TextClause)
+                or isinstance(column.type.check, TextClause)
+            ):
+                self.add_literal_import("sqlalchemy", "text")
 
         if column.default:
             self.add_import(column.default)
@@ -533,6 +540,12 @@ class TablesGenerator(CodeGenerator):
                 and coltype.astext_type.length is None
             ):
                 del kwargs["astext_type"]
+
+        if isinstance(coltype, DOMAIN):
+            if isinstance(coltype.default, TextClause):
+                kwargs["default"] = render_callable("text", repr(coltype.default.text))
+            if isinstance(coltype.check, TextClause):
+                kwargs["check"] = render_callable("text", repr(coltype.check.text))
 
         if args or kwargs:
             return render_callable(coltype.__class__.__name__, *args, kwargs=kwargs)

--- a/tests/test_generator_tables.py
+++ b/tests/test_generator_tables.py
@@ -189,6 +189,41 @@ def test_enum_detection(generator: CodeGenerator) -> None:
 
 
 @pytest.mark.parametrize("engine", ["postgresql"], indirect=["engine"])
+def test_domain(generator: CodeGenerator) -> None:
+    Table(
+        "simple_items",
+        generator.metadata,
+        Column(
+            'postal_code',
+            postgresql.DOMAIN(
+                'us_postal_code',
+                Text,
+                constraint_name='valid_us_postal_code',
+                not_null=False,
+                check=text("VALUE ~ '^\\d{5}$' OR VALUE ~ '^\\d{5}-\\d{4}$'"),
+            ),
+            nullable=False,
+        ),
+    )
+
+    validate_code(
+        generator.generate(),
+        """\
+        from sqlalchemy import Column, MetaData, Table, Text, text
+        from sqlalchemy.dialects.postgresql import DOMAIN
+
+        metadata = MetaData()
+
+
+        t_simple_items = Table(
+            'simple_items', metadata,
+            Column('postal_code', DOMAIN('us_postal_code', Text(), constraint_name='valid_us_postal_code', not_null=False, check=text("VALUE ~ '^\\\\d{5}$' OR VALUE ~ '^\\\\d{5}-\\\\d{4}$'")), nullable=False)
+        )
+        """,
+    )
+
+
+@pytest.mark.parametrize("engine", ["postgresql"], indirect=["engine"])
 def test_column_adaptation(generator: CodeGenerator) -> None:
     Table(
         "simple_items",


### PR DESCRIPTION
Related to #329

The sqlalchemy dependency version was changed to get [this PR](https://github.com/sqlalchemy/sqlalchemy/pull/10729).

The [DOMAIN class](https://github.com/sqlalchemy/sqlalchemy/blob/c8d73b74733fa9f12b7b95a5885e808e6b31f1c6/lib/sqlalchemy/dialects/postgresql/named_types.py#L384) has
* two parameters that can take a `TextClause`: these get wrapped with `text()` as needed, similarly to `server_default` params
* one parameter which is a SQLAlchemy type: this gets imported, similarly to array item types