### PR TITLE
Add force_class option

### DIFF
--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -713,6 +713,7 @@ class DeclarativeGenerator(TablesGenerator):
         "use_inflect",
         "nojoined",
         "nobidi",
+        "force_class"
     }
 
     def __init__(
@@ -774,9 +775,7 @@ class DeclarativeGenerator(TablesGenerator):
 
             # Only form model classes for tables that have a primary key and are not
             # association tables
-            if not table.primary_key:
-                models_by_table_name[qualified_name] = Model(table)
-            else:
+            if table.primary_key or "force_class" in self.options:
                 model = ModelClass(table)
                 models_by_table_name[qualified_name] = model
 
@@ -784,6 +783,8 @@ class DeclarativeGenerator(TablesGenerator):
                 for column in table.c:
                     column_attr = ColumnAttribute(model, column)
                     model.columns.append(column_attr)
+            else:
+                models_by_table_name[qualified_name] = Model(table)
 
         # Add relationships
         for model in models_by_table_name.values():

--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -713,7 +713,7 @@ class DeclarativeGenerator(TablesGenerator):
         "use_inflect",
         "nojoined",
         "nobidi",
-        "force_class"
+        "force_class",
     }
 
     def __init__(

--- a/tests/test_generator_declarative.py
+++ b/tests/test_generator_declarative.py
@@ -1511,10 +1511,8 @@ server_default=text("'test'"))
     )
 
 
-def test_force_class(
-    metadata: MetaData, engine: Engine
-) -> None:
-    generator = DeclarativeGenerator(metadata, engine, options = ["force_class"])
+def test_force_class(metadata: MetaData, engine: Engine) -> None:
+    generator = DeclarativeGenerator(metadata, engine, options=["force_class"])
     Table(
         "simple",
         generator.metadata,
@@ -1522,8 +1520,9 @@ def test_force_class(
         Column("b", VARCHAR),
     )
 
-
-    assert generator.generate() == """\
+    assert (
+        generator.generate()
+        == """\
 from typing import Optional
 
 from sqlalchemy import Integer, String
@@ -1539,3 +1538,4 @@ class Simple(Base):
     a: Mapped[Optional[int]] = mapped_column(Integer)
     b: Mapped[Optional[str]] = mapped_column(String)
 """
+    )

--- a/tests/test_generator_declarative.py
+++ b/tests/test_generator_declarative.py
@@ -1509,3 +1509,33 @@ class Simple(Base):
 server_default=text("'test'"))
 """,
     )
+
+
+def test_force_class(
+    metadata: MetaData, engine: Engine
+) -> None:
+    generator = DeclarativeGenerator(metadata, engine, options = ["force_class"])
+    Table(
+        "simple",
+        generator.metadata,
+        Column("a", INTEGER),
+        Column("b", VARCHAR),
+    )
+
+
+    assert generator.generate() == """\
+from typing import Optional
+
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Simple(Base):
+    __tablename__ = 'simple'
+
+    a: Mapped[Optional[int]] = mapped_column(Integer)
+    b: Mapped[Optional[str]] = mapped_column(String)
+"""


### PR DESCRIPTION
The current logic is that, if a table has no primary key, it doesn't use the declarative class generator. However, sqlite has the hidden `rowid` column which acts as a primary key. For this reason, I want to generate a dataclass and then add `rowid` as the primary key so that I get all the nice type safety of a dataclass.  There are probably also other use cases for ignoring this rule.

Thus, this PR adds a new option called `force_class` that will generate a dataclass even if there is no obvious primary key.