### PR TITLE
Correct imports and improve generation logic in `SQLModelGenerator`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,9 @@ jobs:
         allow-prereleases: true
         cache: pip
         cache-dependency-path: pyproject.toml
-    - name: Install dependencies
+    - name: Install basic dependencies
+      run: pip install -e .
+    - name: Install test dependencies
       run: pip install -e .[test]
     - name: Test with pytest
       run: coverage run -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,7 @@ jobs:
         allow-prereleases: true
         cache: pip
         cache-dependency-path: pyproject.toml
-    - name: Install basic dependencies
-      run: pip install -e .
-    - name: Install test dependencies
+    - name: Install dependencies
       run: pip install -e .[test]
     - name: Test with pytest
       run: coverage run -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
         cache-dependency-path: pyproject.toml
     - name: Install dependencies
       run: pip install -e .[test]
+    - name: Install sqlmodel dependency
+      run: pip install -e .[sqlmodel]
     - name: Test with pytest
       run: coverage run -m pytest
     - name: Upload Coverage


### PR DESCRIPTION
In fact, I found that there are some problems in the code generated by `sqlacodegen` for `sqlmodel`, which is manifested in the introduction of redundant class `CHAR` and the `mapped_column` does not been import. The following is a detailed description of the problem:

<img width="851" alt="image" src="https://github.com/user-attachments/assets/629537a8-73a7-41c7-a8ad-9d760f675e3d">


(1) When encountering `CHAR(36)` and `CHAR(36, 'utf8mb4_general_ci')`, `sqlacodegen` will repeatedly import from different sources
```
from sqlalchemy import CHAR
from sqlalchemy.dialects.mysql import CHAR
```
**The adjustment I made was to focus on sorted and high-priority imports, and to make a warn about duplicate imports.**

for example:
```
WARN: Duplicate imports `{'CHAR'}`  are detected from the package `sqlalchemy.dialects.mysql` and will be filtered, 
which may cause abnormal behavior.
```

In fact, "from sqlalchemy import CHAR" supports general projects of multiple databases, while "from sqlalchemy.dialects.mysql import CHAR" is specifically for MySQL projects. If you project requires cross-database compatibility or you are not sure about the target database type, it is safer to use "sqlalchemy.CHAR".

(2) `sqlmodel` does not support `mapped_column` in the latest release(https://github.com/fastapi/sqlmodel/releases/tag/0.0.22), although someone has proposed a PR (https://github.com/fastapi/sqlmodel/pull/1143), so `Column` should be used for the generation of sqlmodels for the time being