### PR TITLE
adding arg to create model classes for tables w/o primary keys

### DIFF
--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -725,7 +725,7 @@ class DeclarativeGenerator(TablesGenerator):
         "use_inflect",
         "nojoined",
         "nobidi",
-        "model_classes"
+        "model_classes",
     }
 
     def __init__(

--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -725,6 +725,7 @@ class DeclarativeGenerator(TablesGenerator):
         "use_inflect",
         "nojoined",
         "nobidi",
+        "model_classes"
     }
 
     def __init__(
@@ -763,6 +764,7 @@ class DeclarativeGenerator(TablesGenerator):
                 self.add_literal_import("sqlalchemy.orm", "relationship")
 
     def generate_models(self) -> list[Model]:
+        is_model_classes_only = "model_classes" in self.options
         models_by_table_name: dict[str, Model] = {}
 
         # Pick association tables from the metadata into their own set, don't process
@@ -786,7 +788,7 @@ class DeclarativeGenerator(TablesGenerator):
 
             # Only form model classes for tables that have a primary key and are not
             # association tables
-            if not table.primary_key:
+            if not is_model_classes_only and not table.primary_key:
                 models_by_table_name[qualified_name] = Model(table)
             else:
                 model = ModelClass(table)


### PR DESCRIPTION
In order to maintain some existing code there is a need to create Model Classes for all tables in database. So here I added a simple option to create Model Classes for every table  