### PR TITLE
patch-citext-version-display

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version history
   the array elements
 - Added support for specifying engine arguments via ``--engine-arg``
   (PR by @LajosCseppento)
+- Fixed ``sqlalchemy-citext`` importlib support (PR by @oaimtiaz)
 
 **3.0.0**
 

--- a/src/sqlacodegen/cli.py
+++ b/src/sqlacodegen/cli.py
@@ -105,7 +105,7 @@ def main() -> None:
         return
 
     if citext:
-        print(f"Using sqlalchemy-citext {version('citext')}")
+        print(f"Using sqlalchemy-citext {version('sqlalchemy-citext')}")
 
     if geoalchemy2:
         print(f"Using geoalchemy2 {version('geoalchemy2')}")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This PR corrects the package name used when retrieving the version number for `sqlalchemy-citext`. Previously, the code called:
```python
version('citext')
```
which raised a `PackageNotFoundError`:
```
importlib.metadata.PackageNotFoundError: citext
```

Although `sqlalchemy-citext` can be imported as `citext`, the correct package identifier for `importlib.metadata.version()` is `sqlalchemy-citext`. This PR updates the call accordingly:
```python
version('sqlalchemy-citext')
```
## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [x] You've added a new changelog entry (in `CHANGES.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.
