### PR TITLE
Temporarily set an upper boundary for SQLAlchemy version to tackle breaking table API changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Version history
   ``sqlalchemy-citext``, resolving ``PackageNotFoundError`` (PR by @oaimtiaz)
 - Prevent double pluralization (PR by @dkratzert)
 - Fixes DOMAIN extending JSON/JSONB data types (PR by @sheinbergon)
+- Temporarily restrict SQLAlchemy version to 2.0.41 (PR by @sheinbergon)
 
 **3.0.0**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "SQLAlchemy >= 2.0.29",
+    "SQLAlchemy >= 2.0.29,<2.0.42",
     "inflect >= 4.0.0",
     "importlib_metadata; python_version < '3.10'",
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

Set an upper boundary for SQLalchemy dependency until 2.0.42 is supported

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [x] You've added a new changelog entry (in `CHANGES.rst`).

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
