### PR TITLE
Switched to SPDX license classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,10 @@ description = "Automatic model code generator for SQLAlchemy"
 readme = "README.rst"
 authors = [{name = "Alex Grönholm", email = "alex.gronholm@nextday.fi"}]
 keywords = ["sqlalchemy"]
-license = {text = "MIT"}
+license = "MIT"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Environment :: Console",
     "Topic :: Database",
     "Topic :: Software Development :: Code Generators",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Updates project metadata to use SPDX classifier for the license. Specifying license information in PyPI classifiers has been deprecated.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've added a new changelog entry (in `CHANGES.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/sqlacodegen/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
