### PR TITLE
Dropped support for Python 3.9 and test on 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@ Version history
 ===============
 
 **UNRELEASED**
+
+- Dropped support for Python 3.9
 - Fix Postgres ``DOMAIN`` adaptation regression introduced in SQLAlchemy 2.0.42 (PR by @sheinbergon)
 
 **3.1.1**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,18 +21,16 @@ classifiers = [
     "Topic :: Software Development :: Code Generators",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "SQLAlchemy >= 2.0.29",
     "inflect >= 4.0.0",
-    "importlib_metadata; python_version < '3.10'",
-    "stdlib-list; python_version < '3.10'"
 ]
 dynamic = ["version"]
 
@@ -95,7 +93,7 @@ relative_files = true
 show_missing = true
 
 [tool.tox]
-env_list = ["py39", "py310", "py311", "py312", "py313"]
+env_list = ["py310", "py311", "py312", "py313", "py314"]
 skip_missing_interpreters = true
 
 [tool.tox.env_run_base]

--- a/src/sqlacodegen/cli.py
+++ b/src/sqlacodegen/cli.py
@@ -4,6 +4,7 @@ import argparse
 import ast
 import sys
 from contextlib import ExitStack
+from importlib.metadata import entry_points, version
 from typing import Any, TextIO
 
 from sqlalchemy.engine import create_engine
@@ -23,11 +24,6 @@ try:
     import pgvector.sqlalchemy
 except ImportError:
     pgvector = None
-
-if sys.version_info < (3, 10):
-    from importlib_metadata import entry_points, version
-else:
-    from importlib.metadata import entry_points, version
 
 
 def _parse_engine_arg(arg_str: str) -> tuple[str, Any]:

--- a/src/sqlacodegen/models.py
+++ b/src/sqlacodegen/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Any, Union
+from typing import Any
 
 from sqlalchemy.sql.schema import Column, ForeignKeyConstraint, Table
 
@@ -52,7 +52,7 @@ class ColumnAttribute:
         return self.name
 
 
-JoinType = tuple[Model, Union[ColumnAttribute, str], Model, Union[ColumnAttribute, str]]
+JoinType = tuple[Model, ColumnAttribute | str, Model, ColumnAttribute | str]
 
 
 @dataclass


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This drops support for Python 3.9 and adds Python 3.14 to the tox configuration and GitHub CI matrix.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [X] You've added a new changelog entry (in `CHANGES.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/sqlacodegen/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
