### PR TITLE
Fixed the rendering of the metadata argument with SQLModel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version history
 - Fixed rendering of inherited keyword arguments for dialect-specific types that use
   ``**kwargs`` in their initializers (such as MySQL ``CHAR`` with ``collation``) while
   preserving existing ``*args`` rendering behavior (PR by @hyoj0942)
+- Fixed missing metadata argument when rendering plain tables with the SQLModel
+  generator
 
 **4.0.1**
 

--- a/tests/test_generator_sqlmodel.py
+++ b/tests/test_generator_sqlmodel.py
@@ -366,3 +366,24 @@ def test_array_enum_named_with_schema(generator: CodeGenerator) -> None:
                 tags: list[TagEnum] = Field(sa_column=Column('tags', ARRAY(Enum(TagEnum, values_callable=lambda cls: [member.value for member in cls], name='tag_enum', schema='custom_schema')), nullable=False))
         """,
     )
+
+
+def test_fallback_table(generator: CodeGenerator) -> None:
+    Table(
+        "simple_fallback",
+        generator.metadata,
+        Column("field", VARCHAR(20), nullable=False),
+    )
+
+    validate_code(
+        generator.generate(),
+        """\
+            from sqlalchemy import Column, String, Table
+            from sqlmodel import SQLModel
+
+            t_simple_fallback = Table(
+                'simple_fallback', SQLModel.metadata,
+                Column('field', String(20), nullable=False)
+            )
+        """,
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This fixes the missing metadata argument when rendering a plain `Table` with the SQLModel generator.
It contains a hack that replaces `self.base.metadata_ref` which is otherwise overridden by the declarative generator during `generate_models()`.

Fixes #465. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) which would fail without your patch
- [X] You've added a new changelog entry (in `CHANGES.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/sqlacodegen/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
