### PR TITLE
fix: replace print() with logging in CLI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version history
 
 - Added autoincrement to primary key columns to prevent missing field errors.
   (`#473 <https://github.com/agronholm/sqlacodegen/issues/473>`_; PR by @jtmonroe)
+- Replaced informational ``print()`` calls in the CLI with ``logging``, preventing
+  status messages from corrupting stdout when piping generated output
+  (`#451 <https://github.com/agronholm/sqlacodegen/issues/451>`_)
 
 **4.0.3**
 

--- a/src/sqlacodegen/cli.py
+++ b/src/sqlacodegen/cli.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import argparse
 import ast
+import logging
 import sys
 from contextlib import ExitStack
 from importlib.metadata import entry_points, version
 from typing import Any, TextIO
+
+logger = logging.getLogger(__name__)
 
 from sqlalchemy.engine import create_engine
 from sqlalchemy.schema import MetaData
@@ -49,6 +52,7 @@ def _parse_engine_args(arg_list: list[str]) -> dict[str, Any]:
 
 
 def main() -> None:
+    logging.basicConfig(stream=sys.stderr, level=logging.INFO)
     generators = {ep.name: ep for ep in entry_points(group="sqlacodegen.generators")}
     parser = argparse.ArgumentParser(
         description="Generates SQLAlchemy model code from an existing database."
@@ -96,18 +100,18 @@ def main() -> None:
         return
 
     if not args.url:
-        print("You must supply a url\n", file=sys.stderr)
+        logger.error("You must supply a url")
         parser.print_help()
         return
 
     if citext:
-        print(f"Using sqlalchemy-citext {version('sqlalchemy-citext')}")
+        logger.info("Using sqlalchemy-citext %s", version("sqlalchemy-citext"))
 
     if geoalchemy2:
-        print(f"Using geoalchemy2 {version('geoalchemy2')}")
+        logger.info("Using geoalchemy2 %s", version("geoalchemy2"))
 
     if pgvector:
-        print(f"Using pgvector {version('pgvector')}")
+        logger.info("Using pgvector %s", version("pgvector"))
 
     # Use reflection to fill in the metadata
     engine_args = _parse_engine_args(args.engine_arg)
@@ -123,10 +127,7 @@ def main() -> None:
 
     if not generator.views_supported:
         name = generator_class.__name__
-        print(
-            f"VIEW models will not be generated when using the '{name}' generator",
-            file=sys.stderr,
-        )
+        logger.warning("VIEW models will not be generated when using the '%s' generator", name)
 
     for schema in schemas:
         metadata.reflect(

--- a/src/sqlacodegen/cli.py
+++ b/src/sqlacodegen/cli.py
@@ -127,7 +127,9 @@ def main() -> None:
 
     if not generator.views_supported:
         name = generator_class.__name__
-        logger.warning("VIEW models will not be generated when using the '%s' generator", name)
+        logger.warning(
+            "VIEW models will not be generated when using the '%s' generator", name
+        )
 
     for schema in schemas:
         metadata.reflect(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -221,3 +221,24 @@ def test_main() -> None:
         check=True,
     )
     assert completed.stdout.decode().strip() == expected_version
+
+
+def test_informational_messages_go_to_stderr_not_stdout(
+    db_path: Path, tmp_path: Path
+) -> None:
+    """Informational log messages must not corrupt stdout (the generated code)."""
+    result = subprocess.run(
+        [
+            "sqlacodegen",
+            f"sqlite:///{db_path}",
+            "--generator",
+            "tables",
+            "--outfile",
+            str(tmp_path / "outfile"),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    # Nothing informational should bleed into stdout
+    assert result.stdout == b""


### PR DESCRIPTION
Closes #451.

Informational messages about optional dependencies (citext, geoalchemy2, pgvector) and generator warnings were sent to stdout, corrupting generated code when output is piped or redirected to a file.

## Changes

- Added `import logging` and `logger = logging.getLogger(__name__)` to `cli.py`
- Configured `logging.basicConfig(stream=sys.stderr, level=logging.INFO)` at start of `main()`
- Replaced informational `print()` calls with `logger.info/warning/error`
- Kept `print(version('sqlacodegen'))` for `--version` (intentional stdout output)

## Test

Added `test_informational_messages_go_to_stderr_not_stdout` which asserts stdout is empty when running with `--outfile`, confirming no log messages pollute the output stream.