### PR TITLE
Preserve dialect-specific ARRAY types instead of adapting to generic ARRAY

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Version history
 
 - Added autoincrement to primary key columns to prevent missing field errors.
   (`#473 <https://github.com/agronholm/sqlacodegen/issues/473>`_; PR by @jtmonroe)
+- Preserve dialect-specific ``ARRAY`` types (e.g. ``postgresql.ARRAY``) instead
+  of adapting them to the generic ``sqlalchemy.ARRAY``. The generic type does
+  not implement operators like ``.contains()``, so adapting silently broke
+  PostgreSQL array queries on generated models.
+  (`#441 <https://github.com/agronholm/sqlacodegen/issues/441>`_)
 
 **4.0.3**
 

--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -1036,6 +1036,16 @@ class TablesGenerator(CodeGenerator):
                         column.server_default = None
 
     def get_adapted_type(self, coltype: Any) -> Any:
+        # The generic ``sqlalchemy.ARRAY`` does not implement operators such as
+        # ``.contains()`` that dialect-specific ARRAY types (notably
+        # ``sqlalchemy.dialects.postgresql.ARRAY``) provide. Adapting a
+        # dialect-specific ARRAY to the generic one would silently break user
+        # code that relies on those operators at runtime (see GH-441), so we
+        # keep the original ARRAY class and only adapt its item type.
+        if isinstance(coltype, ARRAY) and type(coltype) is not ARRAY:
+            coltype.item_type = self.get_adapted_type(coltype.item_type)
+            return coltype
+
         compiled_type = coltype.compile(self.bind.engine.dialect)
         for supercls in coltype.__class__.__mro__:
             if not supercls.__name__.startswith("_") and hasattr(

--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -1036,12 +1036,8 @@ class TablesGenerator(CodeGenerator):
                         column.server_default = None
 
     def get_adapted_type(self, coltype: Any) -> Any:
-        # The generic ``sqlalchemy.ARRAY`` does not implement operators such as
-        # ``.contains()`` that dialect-specific ARRAY types (notably
-        # ``sqlalchemy.dialects.postgresql.ARRAY``) provide. Adapting a
-        # dialect-specific ARRAY to the generic one would silently break user
-        # code that relies on those operators at runtime (see GH-441), so we
-        # keep the original ARRAY class and only adapt its item type.
+        # Keep dialect-specific ARRAY subclasses; the generic sqlalchemy.ARRAY
+        # is missing operators like .contains() (GH-441).
         if isinstance(coltype, ARRAY) and type(coltype) is not ARRAY:
             coltype.item_type = self.get_adapted_type(coltype.item_type)
             return coltype

--- a/tests/test_generator_tables.py
+++ b/tests/test_generator_tables.py
@@ -127,10 +127,15 @@ def test_arrays(generator: CodeGenerator) -> None:
         Column("int_array", postgresql.ARRAY(INTEGER)),
     )
 
+    # The dialect-specific ``postgresql.ARRAY`` is preserved because the generic
+    # ``sqlalchemy.ARRAY`` does not implement operators such as ``.contains()``
+    # (see GH-441). The item types are still adapted to their generic
+    # equivalents (``DOUBLE_PRECISION`` -> ``Double``, ``INTEGER`` -> ``Integer``).
     validate_code(
         generator.generate(),
         """\
-        from sqlalchemy import ARRAY, Column, Double, Integer, MetaData, Table
+        from sqlalchemy import Column, Double, Integer, MetaData, Table
+        from sqlalchemy.dialects.postgresql import ARRAY
 
         metadata = MetaData()
 
@@ -139,6 +144,43 @@ def test_arrays(generator: CodeGenerator) -> None:
             'simple_items', metadata,
             Column('dp_array', ARRAY(Double(precision=53))),
             Column('int_array', ARRAY(Integer()))
+        )
+        """,
+    )
+
+
+@pytest.mark.parametrize("engine", ["postgresql"], indirect=["engine"])
+def test_array_preserves_dialect_for_runtime_operators(
+    generator: CodeGenerator,
+) -> None:
+    """Regression test for GH-441.
+
+    A ``text[]`` column should generate ``sqlalchemy.dialects.postgresql.ARRAY``
+    (not the generic ``sqlalchemy.ARRAY``) so that PostgreSQL array operators
+    like ``.contains()`` work on the generated model. The generic ARRAY raises
+    ``NotImplementedError: ARRAY.contains() not implemented for the base ARRAY
+    type; please use the dialect-specific ARRAY type``.
+    """
+    Table(
+        "simple_items",
+        generator.metadata,
+        Column("id", postgresql.TEXT, primary_key=True),
+        Column("tags", postgresql.ARRAY(postgresql.TEXT)),
+    )
+
+    validate_code(
+        generator.generate(),
+        """\
+        from sqlalchemy import Column, MetaData, Table, Text
+        from sqlalchemy.dialects.postgresql import ARRAY
+
+        metadata = MetaData()
+
+
+        t_simple_items = Table(
+            'simple_items', metadata,
+            Column('id', Text, primary_key=True),
+            Column('tags', ARRAY(Text()))
         )
         """,
     )

--- a/tests/test_generator_tables.py
+++ b/tests/test_generator_tables.py
@@ -127,10 +127,6 @@ def test_arrays(generator: CodeGenerator) -> None:
         Column("int_array", postgresql.ARRAY(INTEGER)),
     )
 
-    # The dialect-specific ``postgresql.ARRAY`` is preserved because the generic
-    # ``sqlalchemy.ARRAY`` does not implement operators such as ``.contains()``
-    # (see GH-441). The item types are still adapted to their generic
-    # equivalents (``DOUBLE_PRECISION`` -> ``Double``, ``INTEGER`` -> ``Integer``).
     validate_code(
         generator.generate(),
         """\
@@ -153,14 +149,7 @@ def test_arrays(generator: CodeGenerator) -> None:
 def test_array_preserves_dialect_for_runtime_operators(
     generator: CodeGenerator,
 ) -> None:
-    """Regression test for GH-441.
-
-    A ``text[]`` column should generate ``sqlalchemy.dialects.postgresql.ARRAY``
-    (not the generic ``sqlalchemy.ARRAY``) so that PostgreSQL array operators
-    like ``.contains()`` work on the generated model. The generic ARRAY raises
-    ``NotImplementedError: ARRAY.contains() not implemented for the base ARRAY
-    type; please use the dialect-specific ARRAY type``.
-    """
+    """Regression test for GH-441."""
     Table(
         "simple_items",
         generator.metadata,


### PR DESCRIPTION
Fixes #441.

## Problem

When sqlacodegen reflects a PostgreSQL `text[]` (or any dialect-specific
ARRAY) column, `get_adapted_type` walks the column type's MRO and substitutes
the original `sqlalchemy.dialects.postgresql.ARRAY` with the generic
`sqlalchemy.ARRAY`. The generic ARRAY does not implement operators like
`.contains()`, `.any()` or `.all()`, so calling them on a generated model
raises at runtime:

```
NotImplementedError: ARRAY.contains() not implemented for the base ARRAY type;
please use the dialect-specific ARRAY type
```

The existing workaround (`--options keep_dialect_types`) opts out of *all*
generic-type adaptation, which is more than the user usually wants:
`Integer` becomes `INTEGER`, `Boolean` becomes `BOOLEAN`, and so on.

## Fix

`get_adapted_type` now special-cases ARRAY: when the input is a subclass of
the generic `ARRAY` (i.e. a dialect-specific ARRAY such as
`postgresql.ARRAY`), the original class is preserved and only the item type
is adapted recursively. Plain `sqlalchemy.ARRAY` inputs are unaffected, and
no other type's adaptation behavior changes.

This matches the direction the maintainer pointed to in the issue thread
("Should the array type perhaps be special cased? I think that overall the
generalization of types is correct.").

## Generated output before / after

Input column: `Column("tags", postgresql.ARRAY(postgresql.TEXT))`

Before:

```python
from sqlalchemy import ARRAY, Column, Table, Text

# tags.contains([...]) -> NotImplementedError at runtime
Column('tags', ARRAY(Text()))
```

After:

```python
from sqlalchemy import Column, Table, Text
from sqlalchemy.dialects.postgresql import ARRAY

# tags.contains([...]) -> 'tags @> :tags_1'
Column('tags', ARRAY(Text()))
```

Item types are still adapted: `postgresql.DOUBLE_PRECISION` still becomes
`Double`, `postgresql.TEXT` still becomes `Text`. Only the outer `ARRAY`
class is kept.

## Tests

- The existing `test_arrays` in `tests/test_generator_tables.py` is
  updated to expect `from sqlalchemy.dialects.postgresql import ARRAY`
  for inputs constructed with `postgresql.ARRAY(...)`. The item-type
  adaptation it was already exercising (`DOUBLE_PRECISION` -> `Double`,
  `INTEGER` -> `Integer`) is preserved.
- A new `test_array_preserves_dialect_for_runtime_operators` is added as
  a focused regression test that mirrors the scenario from the issue
  (`text[]` column) and documents *why* the dialect-specific ARRAY is
  required.
- Full test suite passes (`pytest -q` -> 157 passed). `ruff check`,
  `ruff format --check`, and `mypy src/sqlacodegen/generators.py` all
  pass.

## Notes / scope

- Tests that construct `ARRAY(SAEnum(...))` using the generic
  `sqlalchemy.ARRAY` directly continue to work unchanged, because the
  early-return only triggers when `type(coltype) is not ARRAY` (i.e.
  the input is a dialect-specific subclass).
- The `keep_dialect_types` option is unaffected; this change improves
  the default path, which is what the workaround was previously needed
  to escape.